### PR TITLE
fix: resolve title/body widgets by CSS class for GNOME 49 compat

### DIFF
--- a/src/shell/notification-widgets.ts
+++ b/src/shell/notification-widgets.ts
@@ -17,8 +17,8 @@ export type NotificationWidgets = {
   sourceText: Clutter.Text | null;
   source: St.Bin | null;
   time: St.Bin | null;
-  title: St.Bin | null;
-  body: St.Bin | null;
+  title: St.Label | null;
+  body: St.Label | null;
   sourceName: string;
   titleText: string;
   bodyText: string;
@@ -77,6 +77,23 @@ function readText(actor: Clutter.Actor | null | undefined) {
   return (actor as Clutter.Text | null)?.text ?? "";
 }
 
+function findByClass(
+  root: Clutter.Actor | null | undefined,
+  className: string,
+): St.Label | null {
+  if (!root) return null;
+  const n = root.get_n_children();
+  for (let i = 0; i < n; i++) {
+    const child = root.get_child_at_index(i) as St.Widget | null;
+    if (!child) continue;
+    if (child.get_style_class_name?.()?.split(" ").includes(className))
+      return child as St.Label;
+    const found = findByClass(child, className);
+    if (found) return found;
+  }
+  return null;
+}
+
 export function resolveNotificationWidgets(
   messageTrayContainer: Clutter.Actor | null | undefined,
 ): NotificationWidgets | null {
@@ -92,17 +109,19 @@ export function resolveNotificationWidgets(
   const source = headerContent?.get_child_at_index(0) as St.Bin | null;
   const sourceText = source?.get_first_child() as Clutter.Text | null;
   const time = headerContent?.get_child_at_index(1) as St.Bin | null;
-  const content = notification?.get_child_at_index(1);
-  const contentBody = content?.get_child_at_index(1) as St.BoxLayout | null;
-  const title = contentBody?.get_child_at_index(0) as St.Bin | null;
-  const body = contentBody?.get_child_at_index(1) as St.Bin | null;
+
+  // Use CSS class lookup for title/body — resilient to layout changes across
+  // GNOME versions. Index-based traversal broke in GNOME 49 because _actionBin
+  // is now always added as the last child of the notification vbox (even when
+  // hidden), so get_last_child() returned _actionBin instead of the content hbox.
+  const title = findByClass(notification, "message-title");
+  const body = findByClass(notification, "message-body");
+
   const metadata = getNotificationMetadata(container);
 
   const sourceName = sourceText?.text ?? metadata?.sourceName ?? "";
-  const titleText =
-    readText(title?.get_first_child()) || metadata?.titleText || "";
-  const bodyText =
-    readText(body?.get_first_child()) || metadata?.bodyText || "";
+  const titleText = readText(title) || metadata?.titleText || "";
+  const bodyText = readText(body) || metadata?.bodyText || "";
 
   setNotificationMetadata(container, {
     sourceName,


### PR DESCRIPTION
## Summary

- Custom Title and Body Text colors (and font sizes) have no effect on GNOME Shell 49 because the widget-tree traversal in `resolveNotificationWidgets` can no longer find the title/body `St.Label`s.
- In GNOME 49, `messageList.js` always adds `_actionBin` as the last child of the notification `vbox` (even when hidden), so `notification.get_last_child()` returns `_actionBin` instead of the content `hbox`. That breaks the subsequent `contentBody.get_child_at_index(...)` calls — `title` and `body` end up `null` and `set_style()` is never called on them.
- Replace the brittle, fully-index-based walk with a recursive `findByClass()` that locates the title/body labels by their stable CSS class names (`message-title`, `message-body`). Those class names are set by GNOME Shell itself and are a far more stable contract than child indices.
- Also reads `titleText`/`bodyText` directly from the `St.Label` instead of `get_first_child()` (an `St.Label` has no relevant child actor to read from — this was only working before because the old traversal pointed to a container whose first child was the label).

## Why CSS classes instead of indices

The old traversal assumed `_actionBin` was only present when the notification had actions. When GNOME Shell added `_actionBin` as a permanent always-present vbox child, every index-based call downstream was off by one. A CSS-class lookup is immune to future reshuffling as long as GNOME Shell keeps the class names on these labels — and those names have been stable for many releases.

Only `title` and `body` were changed to class-based lookup. `source` and `time` already resolved correctly via the header path and were left alone for a minimal diff.

## Test plan

- [x] Tested on GNOME Shell 49.5 (Fedora 43)
- [x] Enable Custom Styles → set Title and Body Text to a non-default color → \`notify-send "Test" "Body"\` → both strings render in the configured color
- [x] App Name and Time colors continue to apply
- [x] Background color continues to apply
- [x] Font size fields for Title and Body Text now also take effect (they were broken by the same null-widget issue)
- [x] Notifications with and without action buttons both themed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)